### PR TITLE
Add overrides to allCapsConstantStorageVariables

### DIFF
--- a/rules/allCapsConstantStorageVariables.js
+++ b/rules/allCapsConstantStorageVariables.js
@@ -3,6 +3,9 @@ class AllCapsConstantStorageVariables {
     this.ruleId = 'all-caps-constant-storage-variables';
     this.reporter = reporter;
     this.config = config;
+    this.overrides = new Set([
+      "typeAndVersion"
+    ]);
   }
 
   ContractDefinition(ctx) {
@@ -15,6 +18,7 @@ class AllCapsConstantStorageVariables {
           if (
             type === 'VariableDeclaration' &&
             isDeclaredConst &&
+            !this.overrides.has(name) &&
             name.toUpperCase() !== name
           ) {
             this.reporter.error(


### PR DESCRIPTION
**Description:**
For particular constant variables, we may not want to throw a warning. For example `typeAndVersion` is a part of the TypeAndVersionInterface and only needs to return a constant string. Easier to add a single line instead of making this a full function.