### PR TITLE
Add rule for Interfaces being prefixed with 'I'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Create a `.solhint.json` in your root project directory:
     "chainlink-solidity/prefix-private-functions-with-underscore": "warn",
     "chainlink-solidity/prefix-storage-variables-with-s-underscore": "warn",
     "chainlink-solidity/prefix-immutable-variables-with-i": "warn",
+    "chainlink-solidity/prefix-interfaces-with-i": "warn",
     "chainlink-solidity/all-caps-constant-storage-variables": "warn",
     "chainlink-solidity/no-hardhat-imports": "warn",
     "chainlink-solidity/inherited-constructor-args-not-in-contract-definition": "warn",
@@ -77,6 +78,7 @@ src/Counter.sol
 | `prefix-private-functions-with-underscore`              | Naming convention                                                                     |
 | `prefix-storage-variables-with-s-underscore`            | Naming convention                                                                     |
 | `prefix-immutable-variables-with-i`                     | Naming convention                                                                     |
+| `prefix-interfaces-with-i`                              | Naming convention                                                                     |
 | `all-caps-constant-storage-variables`                   | Naming convention                                                                     |
 | `no-hardhat-imports`                                    | Leftover `hardhat/*.sol` imports not allowed                                          |
 | `inherited-constructor-args-not-in-contract-definition` | Inherited contract constructor arguments should be specified in the constructor block |

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const PrefixInternalFunctionsWithUnderscore = require('./rules/prefixInternalFun
 const PrefixPrivateFunctionsWithUnderscore = require('./rules/prefixPrivateFunctionsWithUnderscore.js');
 const PrefixStorageVariablesWithSUnderscore = require('./rules/prefixStorageVariablesWithSUnderscore.js');
 const PrefixImmutableVariablesWithI = require('./rules/prefixImmutableVariablesWithI');
+const PrefixInterfacesWithI = require('./rules/prefixInterfacesWithI');
 const AllCapsConstantStorageVariables = require('./rules/allCapsConstantStorageVariables.js');
 const NoHardhatImports = require('./rules/noHardhatImports.js');
 const InheritedConstructorArgsNotInContractDefinition = require('./rules/inheritedConstructorArgsNotInContractDefinition.js');
@@ -14,6 +15,7 @@ module.exports = [
   PrefixPrivateFunctionsWithUnderscore,
   PrefixStorageVariablesWithSUnderscore,
   PrefixImmutableVariablesWithI,
+  PrefixInterfacesWithI,
   AllCapsConstantStorageVariables,
   NoHardhatImports,
   InheritedConstructorArgsNotInContractDefinition,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@chainlink/solhint-plugin-chainlink-solidity",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "index.js"
 }

--- a/rules/prefixInterfacesWithI.js
+++ b/rules/prefixInterfacesWithI.js
@@ -1,0 +1,29 @@
+class PrefixInterfacesWithI {
+  constructor(reporter, config) {
+    this.ruleId = "prefix-interfaces-with-i";
+    this.reporter = reporter;
+    this.config = config;
+  }
+
+  ContractDefinition(ctx) {
+    const { type, kind, name } = ctx;
+
+    if (kind === "interface") {
+      if (name.endsWith("Interface")) {
+        this.reporter.error(
+          ctx,
+          this.ruleId,
+          `Interface ${name} is suffixed with 'Interface', should instead be prefixed with 'I' e.g. 'IFoo'`
+        );
+      } else if (!name.startsWith("I")) {
+        this.reporter.error(
+          ctx,
+          this.ruleId,
+          `Interface ${name} is not prefixed with 'I', e.g. 'IFoo'`
+        );
+      }
+    }
+  }
+}
+
+module.exports = PrefixInterfacesWithI;


### PR DESCRIPTION
- Add solhint rule for enforcing that Interfaces should be named `IFoo` instead of `FooInterface`: https://github.com/smartcontractkit/chainlink/blob/develop/contracts/STYLE_GUIDE.md#interfaces-1

### Testing
Tested by replacing the rules in `chainlink-solhint-rules-example` with my updated rules:

`pnpm solhint` with `interface TestInterface`
```
src/Counter.sol
   4:1   warning  Interface TestInterface is suffixed with 'Interface', should instead be prefixed with 'I' e.g. 'IFoo'     chainlink-solidity/prefix-interfaces-with-i
```
Renamed interface to `interface Test` and re-ran `pnpm solhint`
```
src/Counter.sol
   4:1   warning  Interface Test is not prefixed with 'I', e.g. 'IFoo'     chainlink-solidity/prefix-interfaces-with-i
```